### PR TITLE
Feature/all the request as raw

### DIFF
--- a/.idea/sonarIssues.xml
+++ b/.idea/sonarIssues.xml
@@ -88,6 +88,11 @@
             <set />
           </value>
         </entry>
+        <entry key="$PROJECT_DIR$/example/pubspec.lock">
+          <value>
+            <set />
+          </value>
+        </entry>
         <entry key="$PROJECT_DIR$/example/pubspec.yaml">
           <value>
             <set />

--- a/.idea/sonarIssues.xml
+++ b/.idea/sonarIssues.xml
@@ -83,6 +83,11 @@
             <set />
           </value>
         </entry>
+        <entry key="$PROJECT_DIR$/example/lib/src/presentation/ws_example_widget.dart">
+          <value>
+            <set />
+          </value>
+        </entry>
         <entry key="$PROJECT_DIR$/example/lib/src/ws_example_widget.dart">
           <value>
             <set />

--- a/.idea/sonarlint/issuestore/index.pb
+++ b/.idea/sonarlint/issuestore/index.pb
@@ -32,7 +32,5 @@ M
 example/ios/Runner/Info.plist,e/2/e2dc4e679c0be3a65fc5cd78a18842267605151a
 S
 #lib/airwatch_socket_workaround.dart,b/1/b1a6c05ca08da456aa3a808fdfe45a234191e2dd
-Y
-)lib/src/websocket/airwatch_websocket.dart,8/c/8c638d03fe2ec6809678292250712141460653fe
 E
 example/lib/main.dart,8/5/853a9041dcf81c03edb44066add69a52af9f9b1f

--- a/.idea/sonarlint/issuestore/index.pb
+++ b/.idea/sonarlint/issuestore/index.pb
@@ -22,12 +22,8 @@ M
 .github/workflows/publish.yml,4/6/4639989a2b9ca33671669f3e377b9d0308553f80
 K
 .github/workflows/build.yml,f/e/fe77d5d1439f26e353a42bbd38dece2467ff6558
-D
-example/pubspec.yaml,a/3/a35abf1447e056db5184cc974e2d936424f18658
 o
 ?example/lib/src/presentation/http_multipart_example_widget.dart,f/2/f2af549876f3ffc0d1312793a614a76fc1ce63a2
-d
-4example/lib/src/presentation/http_tryout_widget.dart,7/b/7bc5ddfc5954d27e7f5e16e983af8b7057553102
 K
 lib/src/logger_factory.dart,f/a/fa3babc84b912b219905c88a90f4dbd973cb1ca4
 H
@@ -38,3 +34,5 @@ S
 #lib/airwatch_socket_workaround.dart,b/1/b1a6c05ca08da456aa3a808fdfe45a234191e2dd
 Y
 )lib/src/websocket/airwatch_websocket.dart,8/c/8c638d03fe2ec6809678292250712141460653fe
+E
+example/lib/main.dart,8/5/853a9041dcf81c03edb44066add69a52af9f9b1f

--- a/example/lib/src/presentation/ws_example_widget.dart
+++ b/example/lib/src/presentation/ws_example_widget.dart
@@ -25,7 +25,7 @@ class _WsExampleWidgetState extends State<WsExampleWidget> {
     var theme = Theme.of(context);
     return FutureBuilder(
         future: AirWatchWorkAroundFactory.getInstanceSocketSession<String>(
-            "wss://echo.websocket.org"),
+            "wss://echo.websocket.events"),
         builder: (BuildContext context,
             AsyncSnapshot<AirWatchWebSocketWorkAroundSession<String>>
                 snapshot) {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.2"
+    version: "0.0.4"
   async:
     dependency: transitive
     description:

--- a/ios/Classes/AirWatchHttpWorkAround.swift
+++ b/ios/Classes/AirWatchHttpWorkAround.swift
@@ -281,20 +281,13 @@ class SingleBodyRawHttpRequest: HttpRequestData{
 
 /// Factory for [HttpRequestData] instances
 /// Current implemention uses content-type header to infer what is the right [HttpRequestData] instance
+/// Since version 0.0.3 everything is a "raw" request, therefore we don't need diferent HttpRequestDataFactory anymore
 class HttpRequestDataFactory{
     func build(args: NSDictionary!) throws -> HttpRequestData   {
         let headers = args["headers"] as! NSDictionary
         let contentTypeHeader = (headers["content-type"] as? String) ?? (headers["Content-Type"] as? String);
         // for byte array body
         os_log("HttpRequestDataFactory: build HttpRequestData for contentType %@",log: OSLog.airWatchWorkaroundHttpClient,type: .info,  String(describing: contentTypeHeader))
-        if( contentTypeHeader != nil && contentTypeHeader!.contains("application/json")){
-            os_log("HttpRequestDataFactory: returning SingleBodyStringHttpRequest",log: OSLog.airWatchWorkaroundHttpClient,type: .info)
-            return try SingleBodyStringHttpRequest.buildFromArguments(args: args)
-        }
-//        else if (  contentTypeHeader != nil && contentTypeHeader!.contains("multipart/form-data")){
-//            os_log("HttpRequestDataFactory: returning MultiPartHttpRequest",log: OSLog.airWatchWorkaroundHttpClient,type: .info)
-//            return try MultiPartHttpRequest.buildFromArguments(args: args)
-//        }
         os_log("HttpRequestDataFactory: returning SingleBodyRawHttpRequest",log: OSLog.airWatchWorkaroundHttpClient,type: .info)
         return try SingleBodyRawHttpRequest.buildFromArguments(args: args)
         

--- a/lib/src/air_watch_socket_workaround.dart
+++ b/lib/src/air_watch_socket_workaround.dart
@@ -35,8 +35,7 @@ class AirWatchWorkAroundFactory {
   static AirWatchHttpWorkAround getInstance(
       {AirWatchHttpWorkAroundConfiguration config}) {
     config = config ?? DefaultAirWatchHttpWorkAroundConfiguration();
-    return AirWatchHttpRequestWorkAroundImpl(
-        ContentTypeBasedHttpRequestBodyProviderFactory(), config);
+    return AirWatchHttpRequestWorkAroundImpl(HttpRequestBodyProviderImpl(), config);
   }
 
   static Future<AirWatchWebSocketWorkAroundSession<T>>
@@ -95,6 +94,8 @@ abstract class HttpRequestBodyProvider {
 /// body type of the request.
 /// This information will be then used by the native side of the plugin to
 /// build the actual Request
+/// Note: To be removed on the next version, everything can be a
+@deprecated
 abstract class HttpRequestBodyProviderFactory {
   HttpRequestBodyProvider build(ContentType contentType);
 }

--- a/lib/src/http/air_watch_socket_workaround_impl.dart
+++ b/lib/src/http/air_watch_socket_workaround_impl.dart
@@ -19,10 +19,10 @@ class AirWatchHttpRequestWorkAroundImpl implements AirWatchHttpWorkAround {
   static const defaultPlatform = const MethodChannel(_httpChannelName);
 
   final MethodChannel platform;
-  final HttpRequestBodyProviderFactory _bodyProviderFactory;
+  final HttpRequestBodyProvider _bodyProvider;
   final AirWatchHttpWorkAroundConfiguration _config;
 
-  AirWatchHttpRequestWorkAroundImpl(this._bodyProviderFactory, this._config,
+  AirWatchHttpRequestWorkAroundImpl(this._bodyProvider, this._config,
       {this.platform = defaultPlatform});
 
   @override
@@ -37,8 +37,7 @@ class AirWatchHttpRequestWorkAroundImpl implements AirWatchHttpWorkAround {
     final contentType = requestContentType != null
         ? ContentType.parse(requestContentType)
         : _config.defaultContentType;
-    var bodyProvider = _bodyProviderFactory.build(contentType);
-    var body = await bodyProvider.getBody(request);
+    var body = await _bodyProvider.getBody(request);
 
     Map data = await platform.invokeMethod('doRequest', {
       "url": request.url.toString(),

--- a/lib/src/http/air_watch_socket_workaround_request.dart
+++ b/lib/src/http/air_watch_socket_workaround_request.dart
@@ -6,7 +6,10 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart';
 import '../air_watch_socket_workaround.dart';
 
+/// To be removed on the next version
+/// Use [HttpRequestBodyProviderImpl] directly
 @visibleForTesting
+@deprecated
 class ContentTypeBasedHttpRequestBodyProviderFactory
     implements HttpRequestBodyProviderFactory {
   HttpRequestBodyProvider build(ContentType contentType) {
@@ -17,13 +20,13 @@ class ContentTypeBasedHttpRequestBodyProviderFactory
       case "audio":
       case "video":
       case "image":
-        return RawBodyProvider();
+        return HttpRequestBodyProviderImpl();
       case "multipart":
         return MultipartBodyProvider();
       case "application":
         if (subType == 'json') return StringBodyProvider();
 
-        return RawBodyProvider();
+        return HttpRequestBodyProviderImpl();
       case "text":
         return StringBodyProvider();
       default:
@@ -34,7 +37,10 @@ class ContentTypeBasedHttpRequestBodyProviderFactory
   }
 }
 
+/// To be removed on the next version
+/// Use [HttpRequestBodyProviderImpl] directly
 @visibleForTesting
+@deprecated
 class MultipartBodyProvider implements HttpRequestBodyProvider {
   @override
   Future<String> getBody(BaseRequest request) async {
@@ -62,7 +68,10 @@ class MultipartBodyProvider implements HttpRequestBodyProvider {
   }
 }
 
+/// To be removed on the next version
+/// Use [HttpRequestBodyProviderImpl] directly
 @visibleForTesting
+@deprecated
 class StringBodyProvider implements HttpRequestBodyProvider {
   @override
   Future<String> getBody(BaseRequest request) async {
@@ -85,12 +94,20 @@ class StringBodyProvider implements HttpRequestBodyProvider {
   }
 }
 
+/// Unified implementation of [HttpRequestBodyProvider]
+/// since in the past we had an implementation for different request body types:
+/// for String, Multipart and 'raw'.
+/// This implementation should be enough for all since it will delegate
+/// the conversion of the body to [BaseRequest] and descendants
 @visibleForTesting
-class RawBodyProvider implements HttpRequestBodyProvider {
+class HttpRequestBodyProviderImpl implements HttpRequestBodyProvider {
   @override
   Future<Uint8List> getBody(BaseRequest request) async {
     if (request is Request) {
       return request.bodyBytes;
+    }
+    if (request is MultipartRequest) {
+      return request.finalize().toBytes();
     } else {
       throw ArgumentError(
           'Provided request is not a valid one with a Raw bytes body');
@@ -108,6 +125,9 @@ class RawBodyProvider implements HttpRequestBodyProvider {
   }
 }
 
+/// To be removed on the next version
+/// No longer needed since the introduction of [HttpRequestBodyProviderImpl]
+@deprecated
 class MultipartMessage {
   /// The name of the form field.
   final String name;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: airwatch_socket_workaround
 description: A workaround for AirWatch MDM Socket problem using dart sockets
-version: 0.0.3
+version: 0.0.4
 repository: https://github.com/GoncaloPT/airwatch_socket_workaround
 
 environment:

--- a/test/src/http/air_watch_socket_workaround_test.dart
+++ b/test/src/http/air_watch_socket_workaround_test.dart
@@ -21,7 +21,7 @@ void main() {
 
   group('implementation resilience', () {
     var airWatchSocketWorkAround = AirWatchHttpRequestWorkAroundImpl(
-      ContentTypeBasedHttpRequestBodyProviderFactory(),
+      HttpRequestBodyProviderImpl(),
       defaultConfig,
     );
 
@@ -74,7 +74,7 @@ void main() {
 
   group('send String body', () {
     var airWatchSocketWorkAround = AirWatchHttpRequestWorkAroundImpl(
-      ContentTypeBasedHttpRequestBodyProviderFactory(),
+      HttpRequestBodyProviderImpl(),
       defaultConfig,
     );
     var dummyMethodCallResponseData = '''{
@@ -91,11 +91,11 @@ void main() {
       channel.setMockMethodCallHandler((MethodCall methodCall) async {
         return methodCall.arguments
           ..['statusCode'] = 200
-          ..['data'] = utf8.encode(jsonDecode(methodCall.arguments['body']));
+          ..['data'] = methodCall.arguments['body'];
       });
 
       var request = Request('GET', Uri.parse('http://localhost:8080/'))
-        ..body = jsonEncode(dummyMethodCallResponseData)
+        ..bodyBytes = utf8.encode(dummyMethodCallResponseData)
         ..encoding = utf8
         ..headers.addAll({'Content-Type': contentType.value});
 
@@ -115,7 +115,7 @@ void main() {
       });
 
       var request = Request('GET', Uri.parse('http://localhost:8080/'))
-        ..body = jsonEncode(dummyMethodCallResponseData)
+        ..bodyBytes = utf8.encode(dummyMethodCallResponseData)
         ..encoding = utf8
         ..headers.addAll({'Content-Type': contentType.value});
 
@@ -127,7 +127,7 @@ void main() {
 
   group('send byte array', () {
     var airWatchSocketWorkAround = AirWatchHttpRequestWorkAroundImpl(
-      ContentTypeBasedHttpRequestBodyProviderFactory(),
+      HttpRequestBodyProviderImpl(),
       defaultConfig,
     );
     var contentType = ContentType.binary;
@@ -153,7 +153,7 @@ void main() {
     var data = utf8.encode("ola");
     var contentType = ContentType.binary;
     var airWatchSocketWorkAround = AirWatchHttpRequestWorkAroundImpl(
-      ContentTypeBasedHttpRequestBodyProviderFactory(),
+      HttpRequestBodyProviderImpl(),
       defaultConfig,
     );
 


### PR DESCRIPTION
- Removing support for string and multipart requests between dart and native; everything can be dealt by BaseRequest descendants and ios will always receive bodyBytes.
- Adding multipart test in the example project
- Adding integration test for basic HTTP requests ( string + bytes + multipart )